### PR TITLE
Add sha2 demo

### DIFF
--- a/package-set.dhall
+++ b/package-set.dhall
@@ -1,30 +1,15 @@
--- The upstream seems outdated, hence we define what we need directly below under additions
--- let upstream = https://github.com/dfinity/vessel-package-set/releases/download/mo-0.6.7-20210818/package-set.dhall sha256:c4bd3b9ffaf6b48d21841545306d9f69b57e79ce3b1ac5e1f63b068ca4f89957
+let upstream = https://github.com/timohanke/vessel-package-set/releases/download/mo-0.6.18-20220117/package-set.dhall
 
 let Package =
     { name : Text, version : Text, repo : Text, dependencies : List Text }
 
-let upstream = [] : List Package
-
 let
   -- This is where you can add your own packages to the package-set
-  additions = [
-       { name = "iterext"
-        , version = "v2.0.0"
-        , repo = "https://github.com/timohanke/motoko-iterext.git"
-        , dependencies = [ "base" ] : List Text
-        }
-    ]
+  additions = [] : List Package 
 
 let
   -- This is where you can override existing packages in the package-set
-  overrides = [
-        { name = "base"
-        , version = "dfx-0.8.4"
-        , repo = "https://github.com/dfinity/motoko-base.git"
-        , dependencies = [] : List Text
-        }
-    ]
+  overrides = [] : List Package 
 
 -- in  upstream # additions # overrides
 in upstream # additions # overrides

--- a/src/lib.mo
+++ b/src/lib.mo
@@ -11,6 +11,7 @@ import Int "mo:base/Int";
 import Nat8 "mo:base/Nat8";
 import Buffer "mo:base/Buffer";
 import Debug "mo:base/Debug";
+import SHA2 "mo:sha2";
 
 module {
   // secp256k1
@@ -28,6 +29,10 @@ module {
   public func p() : Nat { p_ };
   /// return the order of the generator of Ec.
   public func r() : Nat { r_ };
+
+  public func test_sha2(b : Blob) : Blob {
+    SHA2.fromBlob(#sha256,b)
+  };
 
   public func toHex(x : Nat) : Text {
     if (x == 0) return "0";

--- a/vessel.dhall
+++ b/vessel.dhall
@@ -1,4 +1,4 @@
 {
-    dependencies = [ "base", "iterext" ],
+    dependencies = [ "base", "sha2" ],
     compiler = Some "0.6.18"
 }


### PR DESCRIPTION
Use upstream vessel package set from https://github.com/timohanke/vessel-package-set
Add sha2 dependency
Demonstrate import statement for sha2 package

Demonstrate use of the sha2 package in a function `test_sha2`. This has to be removed in a subsequent commit.